### PR TITLE
Support CoApp native nugets content folder & native framework

### DIFF
--- a/MSBuild.NugetContentRestore.Tasks/MSBuild.NugetContentRestore.Tasks.csproj
+++ b/MSBuild.NugetContentRestore.Tasks/MSBuild.NugetContentRestore.Tasks.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>2105ebfb</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/MSBuild.NugetContentRestore.Tasks/NugetContentRestoreTask.cs
+++ b/MSBuild.NugetContentRestore.Tasks/NugetContentRestoreTask.cs
@@ -18,7 +18,7 @@ namespace MSBuild.NugetContentRestore.Tasks
 
         #region Private Members
 
-        private readonly string[] _folders = new[] { "Scripts", "Images", "fonts", "content" };
+        private readonly string[] _folders = new[] { "Scripts", "Images", "fonts", "content","native" };
         private readonly string[] _ignoreFilePatterns = new[] { "*.transform", "*.install.xdt", "*.pp" };
 
         private string _configFileFullPath;
@@ -87,7 +87,13 @@ namespace MSBuild.NugetContentRestore.Tasks
                     if (!sourceFolderInfo.Exists) continue;
 
                     Log.LogMessage(MessageImportance.High, "NugetContentRestore :: {0} :: {1} :: Restoring content files", package.FolderName, folder);
+                    if (folder.ToLower()=="native")
+                    {
+                        sourceFolderInfo.CopyTo(ProjectDir, true, filePatterns.ToArray());
+                    }
+                    else { 
                     sourceFolderInfo.CopyTo(Path.Combine(ProjectDir, folder), true, filePatterns.ToArray());
+                    }
                 }
 
                 // Restore Package Content for additional folders (AdditionalFolder)

--- a/MSBuild.NugetContentRestore.nuspec
+++ b/MSBuild.NugetContentRestore.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>MSBuild.NugetContentRestore</id>
-    <version>0.1.6</version>
+    <version>0.1.10</version>
     <authors>Francisco Lopez</authors>
     <owners>Francisco Lopez</owners>
     <projectUrl>https://github.com/panchilo/MSBuild.NugetContentRestore</projectUrl>
@@ -21,9 +21,11 @@
     <tags>nuget content restore msbuild task</tags>
   </metadata>
   <files>
+    <file src="Output\MSBuild.NugetContentRestore.dll" target="build\native" />
+    <file src="MSBuild.NugetContentRestore.targets" target="build\native" />
     <file src="Output\MSBuild.NugetContentRestore.dll" target="build\net40" />
     <file src="MSBuild.NugetContentRestore.targets" target="build\net40" />
-	<file src="tools\" target="tools" />
+    <file src="tools\" target="tools" />
     <file src="readme.txt" target="" />
   </files>
 </package>


### PR DESCRIPTION
To support C++ project nuget which often need to share a content folder structure for relative linking.
The content folder structure often begins with "native" in the nuget but this folder should not be included in the destination
