### PR TITLE
Added SmartRestore feature

### DIFF
--- a/MSBuild.NugetContentRestore.Tasks/Extensions/DirectoryExtensions.cs
+++ b/MSBuild.NugetContentRestore.Tasks/Extensions/DirectoryExtensions.cs
@@ -9,26 +9,43 @@ namespace MSBuild.NugetContentRestore.Tasks.Extensions
     public static class DirectoryExtensions
     {
 
-        public static void CopyTo(this DirectoryInfo source, string destination, bool recursive, Wildcard[] ignorePatterns)
+        public static void CopyTo(this DirectoryInfo source, string destination, bool recursive, Wildcard[] ignorePatterns, bool smartRestore)
         {
             if (source == null) throw new ArgumentNullException("source");
             if (destination == null) throw new ArgumentNullException("destination");
             if (!source.Exists) throw new DirectoryNotFoundException("Source directory not found: " + source.FullName);
 
             var target = new DirectoryInfo(destination);
+            string targetFile;
+            FileInfo targetFileInfo;
+
             if (!target.Exists) target.Create();
+
 
             foreach (var file in source.GetFiles())
             {
                 if (ignorePatterns.Any(p => p.IsMatch(file.Name))) continue;
-                file.CopyTo(Path.Combine(target.FullName, file.Name), true);
+
+                targetFile = Path.Combine(target.FullName, file.Name);
+
+                if (smartRestore)
+                {
+                    // perform additional checks to see if we really need to copy the file
+                    targetFileInfo = new FileInfo(targetFile);
+
+                    // if target exists and source/target have same write time, skip copying this file (don't worry about file contents - turn off SmartRestore if wanting that)
+                    if (targetFileInfo.Exists && file.LastWriteTime.Equals(targetFileInfo.LastWriteTime)) continue;
+                }
+
+
+                file.CopyTo(targetFile, true);
             }
 
             // Exit Condition
             if (!recursive) return;
 
             foreach (var directory in source.GetDirectories())
-                CopyTo(directory, Path.Combine(target.FullName, directory.Name), recursive, ignorePatterns);
+                CopyTo(directory, Path.Combine(target.FullName, directory.Name), recursive, ignorePatterns, smartRestore);
         }
 
     }

--- a/MSBuild.NugetContentRestore.Tasks/Properties/AssemblyInfo.cs
+++ b/MSBuild.NugetContentRestore.Tasks/Properties/AssemblyInfo.cs
@@ -13,5 +13,5 @@ using System.Runtime.InteropServices;
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("1d75b795-214e-43cf-87ad-c34a814c2e57")]
 
-[assembly: AssemblyVersion("0.1.6.0")]
-[assembly: AssemblyFileVersion("0.1.6.0")]
+[assembly: AssemblyVersion("0.1.7.0")]
+[assembly: AssemblyFileVersion("0.1.7.0")]

--- a/MSBuild.NugetContentRestore.nuspec
+++ b/MSBuild.NugetContentRestore.nuspec
@@ -8,6 +8,7 @@
     <projectUrl>https://github.com/panchilo/MSBuild.NugetContentRestore</projectUrl>
     <licenseUrl>https://github.com/panchilo/MSBuild.NugetContentRestore#license</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
+	<developmentDependency>true</developmentDependency>
     <description>MSBuild task to restore Nuget content files to project folder</description>
     <releaseNotes>
 	  * 0.1.6

--- a/MSBuild.NugetContentRestore.nuspec
+++ b/MSBuild.NugetContentRestore.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>MSBuild.NugetContentRestore</id>
-    <version>0.1.6</version>
+    <version>0.1.7</version>
     <authors>Francisco Lopez</authors>
     <owners>Francisco Lopez</owners>
     <projectUrl>https://github.com/panchilo/MSBuild.NugetContentRestore</projectUrl>
@@ -11,6 +11,9 @@
 	<developmentDependency>true</developmentDependency>
     <description>MSBuild task to restore Nuget content files to project folder</description>
     <releaseNotes>
+	  * 0.1.7
+			- Add support for SmartRestore (improves content restore/build time)
+			- fix #14 - Marked nuget package as development dependency only
 	  * 0.1.6
 			- fix #5: Error in importing task if SolutionDir parameter not available.
 	  * 0.1.5

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ An example of two extra folders (content/static, content/Views) being included t
     <NugetContentRestoreTask AdditionalFolders="static;Views" SolutionDir="$(SolutionDir)" ProjectDir="$(ProjectDir)" />
 
 
+###SmartRestore
+SmartRestore detects if a file has changed in the source (package folders) compared to a target file (based on file date only).
+If it hasn't changed, it will skip the file copy, which for packages with large content folders, can significantly improve Visual Studio build performance.  In one large sample, content restore time reduced from 20 seconds down to 2 seconds.
+
+SmartRestore is enabled by default.
+
+To disable SmartRestore, add the `EnableSmartRestore="false"` attribute to the content restore task.
+
+	
+	
 ##License
 The MIT License (MIT)
 


### PR DESCRIPTION
SmartRestore detects if a file has changed in the source (package folders) compared to a target file (based on file date only).
If it hasn't changed, it will skip the file copy, which for packages with large content folders, can significantly improve Visual Studio build performance.  In one large sample, content restore time reduced from 20 seconds down to 2 seconds.

SmartRestore is enabled by default.

To disable SmartRestore, add the `EnableSmartRestore="false"` attribute to the content restore task.
