### PR TITLE
Issue 25, the root C(c)content folder should be handled case insensitive

### DIFF
--- a/MSBuild.NugetContentRestore.Tasks/NugetContentRestoreTask.cs
+++ b/MSBuild.NugetContentRestore.Tasks/NugetContentRestoreTask.cs
@@ -19,7 +19,7 @@ namespace MSBuild.NugetContentRestore.Tasks
 
         #region Private Members
 
-        private readonly string[] _folders = new[] { "Scripts", "Images", "fonts", "content" };
+        private readonly string[] _folders = new[] { "Scripts", "Images", "fonts", "Content" };
         private readonly string[] _ignoreFilePatterns = new[] { "*.transform", "*.install.xdt", "*.pp" };
 
         private string _configFileFullPath;
@@ -167,9 +167,9 @@ namespace MSBuild.NugetContentRestore.Tasks
                 var folder = PathCombineIfExists(packageContentsFullPath, f1);
                 if (folder == null) continue;
 
-                var realFolderShortName = Path.GetFileName(folder);
+                var copyToFolder = Path.GetFileName(f1);
 
-                var destinationFolder = Path.Combine(ProjectDir, realFolderShortName);
+                var destinationFolder = Path.Combine(ProjectDir, copyToFolder);
                 Log.LogMessage(MessageImportance.High, "NugetContentRestore :: {0} :: Restoring files {1} -> {2}", package.FolderName, folder, destinationFolder);
 
                 var sourceFolderInfo = new DirectoryInfo(folder);


### PR DESCRIPTION
Fixed issue https://github.com/panchilo/MSBuild.NugetContentRestore/issues/25
package/C(c)ontent is case insensitive now
+ default content folders and additional content folders are also handled on case insensitive bases.